### PR TITLE
Fixed issue with http request callback parameter order

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -45,7 +45,7 @@ module.exports = (function (api_key, options) {
         method: "POST",
         headers: postmark_headers,
         port: (options.ssl ? 443 : 80)
-      }, function (error, response, body) {
+      }, function (response) {
         if (response.statusCode == 401) {
           throw("Incorrect Postmark API Key header")
         } else if (response.statusCode == 422)  {


### PR DESCRIPTION
NB: This applies to node 0.4.7+ (the issue may be present in earlier versions of Node, but this was the version in which I encountered the error).

The callback for http.request had (error, response, body). The only parameter supplied in the callback should be "response".

The existing code causes an exception as the callback is only supplied 1 parameter, and thus when the code tries to access "response.statusCode", it is trying to access a property of an undefined object.

This patch should make it work.
