### PR TITLE
Response statusCode 422

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -49,7 +49,13 @@ module.exports = (function (api_key, options) {
         if (response.statusCode == 401) {
           throw("Incorrect Postmark API Key header")
         } else if (response.statusCode == 422)  {
-          throw("Incorrect or Malformed JSON message: "+JSON.parse(body["Message"]))
+          var body = '';
+          response.on('data', function (chunk) {
+            body += chunk;
+          });
+          response.on('end', function() {
+            throw("Incorrect or Malformed JSON message: "+JSON.parse(body)["Message"]);
+          });
         } else if (response.statusCode == 200) {
           return true;
         } else  {


### PR DESCRIPTION
In the branch where `response.statusCode == 422`, `body` was undefined.  This commit fixes that.

Cheers,
Caleb
