### PR TITLE
Fixed global leak

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -32,7 +32,7 @@ module.exports = (function (api_key, options) {
       }
       
       
-      postmark_headers = {
+      var postmark_headers = {
         "Accept":  "application/json",
         "Content-Type":  "application/json",
         "X-Postmark-Server-Token":  api_key


### PR DESCRIPTION
I noticed that postmark_headers was defined to global scope. We've checked it with our app and it works, you might wanna write a quick test to make sure nothing is broken. 
