### PR TITLE
Global Scope

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -32,7 +32,7 @@ module.exports = (function (api_key, options) {
       }
       
       
-      postmark_headers = {
+      var postmark_headers = {
         "Accept":  "application/json",
         "Content-Type":  "application/json",
         "X-Postmark-Server-Token": api_key


### PR DESCRIPTION
As of v0.1.8, `postmark_headers` is leaking as a global variable. This was previously addressed in https://github.com/voodootikigod/postmark.js/pull/8 (merged by @voodootikigod), but (I assume inadvertently) reverted in https://github.com/voodootikigod/postmark.js/pull/11 . 

Cheers.
