### PR TITLE
Included response data from Postmark in success callback

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -6,12 +6,12 @@ module.exports = (function (api_key, options) {
   }
   if (typeof options === 'undefined')  { options = {}; }
   if (options.ssl && options.ssl !== true) { options.ssl = false; }
-  
-  
-  
+
+
+
   return {
     send: function(message, callback) {
-      
+
       var valid_parameters = ["From", "To", "Cc", "Bcc", "Subject", "Tag", "HtmlBody", "TextBody", "ReplyTo", "Headers", "Attachments"]
       var valid_attachment_parameters = ["Name", "Content", "ContentType"];
       var attr, attach;
@@ -30,14 +30,14 @@ module.exports = (function (api_key, options) {
           }
         }
       }
-      
-      
+
+
       postmark_headers = {
         "Accept":  "application/json",
         "Content-Type":  "application/json",
         "X-Postmark-Server-Token": api_key
       }
-      
+
       var req = http.request({
         host: "api.postmarkapp.com",
         path: "/email",
@@ -50,7 +50,7 @@ module.exports = (function (api_key, options) {
 				response.on("end", function () {
 					if (response.statusCode == 200) {
 						if (callback) {
-							callback(null, message["To"]);
+							callback(null, JSON.parse(body));
 						}
 					} else {
 						if (callback) {
@@ -64,7 +64,7 @@ module.exports = (function (api_key, options) {
 					}
 				});
       });
-      
+
       req.write(JSON.stringify(message));
       req.end();
     }


### PR DESCRIPTION
Some users might want to save the data returned by Postmark for various reasons. Simple change.
