### PR TITLE
Manage the case where a non-JSON format is resturned by the API

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -54,12 +54,20 @@ module.exports = (function (api_key, options) {
 						}
 					} else {
 						if (callback) {
-							var data = JSON.parse(body);
-							callback({
-								status: response.statusCode,
-								message: data['Message'],
-								code: data['ErrorCode']
-							});
+							try {
+								var data = JSON.parse(body);
+								callback({
+									status: response.statusCode,
+									message: data['Message'],
+									code: data['ErrorCode']
+								});
+							} catch (e) {
+								callback({
+									status: 404,
+									message: "Unsupported Request Method and Protocol",
+									code: -1 // this is a fake error code !
+								});							
+							}
 						}
 					}
 				});


### PR DESCRIPTION
The JSON.parse error is caught and the message "Unsupported Request Method and Protocol" is now returned.

In my case I got the error "Unsupported Request Method and Protocol" placed into an HTML  page. So I fixed it that way, but it could occur because of an other kind of error.
