### PR TITLE
reflect https client and content-length header

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -1,5 +1,3 @@
-var http = require("http");
-
 var check_message_format = function(message) {
   var valid_parameters = ["From", "To", "Cc", "Bcc", "Subject", "Tag", "HtmlBody", "TextBody", "ReplyTo", "Headers", "Attachments"]
   var valid_attachment_parameters = ["Name", "Content", "ContentType"];
@@ -29,19 +27,24 @@ module.exports = (function (api_key, options) {
   if (typeof options === 'undefined')  { options = {}; }
   if (options.ssl && options.ssl !== true) { options.ssl = false; }
   
+  var client = require('http' + (options.ssl === true ? 's' : ''));
+
   var postmark_headers = {
     "Accept":  "application/json",
     "Content-Type":  "application/json",
     "X-Postmark-Server-Token": api_key
   };
-  
+
   return {
     send: function(message, callback) {
       
       // throw exception if message is improperly formatted
       check_message_format(message);
+      var msg = JSON.stringify(message);
+
+      postmark_headers['Content-Length'] = Buffer.byteLength(msg);
       
-      var req = http.request({
+      var req = client.request({
         host: "api.postmarkapp.com",
         path: "/email",
         method: "POST",
@@ -88,7 +91,7 @@ module.exports = (function (api_key, options) {
         }
       });
       
-      req.write(JSON.stringify(message));
+      req.write(msg);
       req.end();
     },
 
@@ -99,7 +102,10 @@ module.exports = (function (api_key, options) {
         check_message_format(message);
       });
 
-      var req = http.request({
+      var msg = JSON.stringify(messages);
+      postmark_headers['Content-Length'] = Buffer.byteLength(msg);
+
+      var req = client.request({
         host: "api.postmarkapp.com",
         path: "/email/batch",
         method: "POST",
@@ -128,7 +134,7 @@ module.exports = (function (api_key, options) {
         }
       });
 
-      req.write(JSON.stringify(messages));
+      req.write(msg);
       req.end();
     }
   }


### PR DESCRIPTION
If ssl enabled use https module. Instead use http.
Flavor Content-Length header.
