### PR TITLE
don't call callback inside of a try statement

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -65,13 +65,9 @@ module.exports = (function (api_key, options) {
             }
           } else {
             if (callback) {
+              var data;
               try {
-                var data = JSON.parse(body);
-                callback({
-                  status: response.statusCode,
-                  message: data['Message'],
-                  code: data['ErrorCode']
-                });
+                data = JSON.parse(body);
               } catch (e) {
                 callback({
                   status: 404,
@@ -79,6 +75,12 @@ module.exports = (function (api_key, options) {
                   code: -1 // this is a fake error code !
                 });
               }
+              callback({
+                status: response.statusCode,
+                message: data['Message'],
+                code: data['ErrorCode']
+              });
+
             }
           }
         });


### PR DESCRIPTION
This fixes some weird behavior if code outside the library raises an Error when the callback is called. In particular this will prevent issues like #24 
