### PR TITLE
Functionality to create 'Test Jobs' instead of real requests

### DIFF
--- a/lib/postmark/index.js
+++ b/lib/postmark/index.js
@@ -26,18 +26,20 @@ module.exports = (function (api_key, options) {
   }
   if (typeof options === 'undefined')  { options = {}; }
   if (options.ssl && options.ssl !== true) { options.ssl = false; }
+  if (options.test && options.test !== true) { options.test = false; }
+
   var client = require('http' + (options.ssl === true ? 's' : ''));
 
   var postmark_headers = {
     "Accept":  "application/json",
-    "Content-Type":  "application/json",
-    "X-Postmark-Server-Token": api_key
+    "Content-Type":  "application/json"
   };
+
+  postmark_headers["X-Postmark-Server-Token"] = options.test === true ? 'POSTMARK_API_TEST' : api_key;
 
   return {
     send: function(message, callback) {
-
-      // throw exception if message is improperly formatted
+      //throw exception if message is improperly formatted
       check_message_format(message);
       var msg = JSON.stringify(message);
 


### PR DESCRIPTION
Added functionality to pass 'test' as an option so that Postmark API handles the request as 'Test Job' and doesn't actually send the email(s). Useful for testing functionality in development environments. 

See: [Handling email in your test environment](http://blog.postmarkapp.com/post/913165552/handling-email-in-your-test-environment)