### PR TITLE
add API-Doc to doclets.io

### DIFF
--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,0 +1,3 @@
+dir: lib/postmark
+articles:
+  - Readme: README.md


### PR DESCRIPTION
Adds documentation to [doclets.io](https://doclets.io) service. Future tags and master branch will be published automatically.

[Preview generated with my account](https://doclets.io/lipp/postmark.js/add-to-doclets)

@voodootikigod If you like this, you are very welcomed to login to https://doclets.io with GitHub OAuth. If you don't like it, I'd be happy to hear what you don't like about it :)

Steps required (3min):
1) @voodootikigod  logs in to doclets.io
2) @voodootikigod  adds postmark.js
3) someone merges this PR
